### PR TITLE
Brightness fix

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1872,8 +1872,8 @@ bool ApiSystem::getBrighness(int& value)
 void ApiSystem::setBrighness(int value)
 {
 #if !WIN32	
-	if (value < 5)
-		value = 5;
+	if (value < 1)
+		value = 1;
 
 	if (value > 100)
 		value = 100;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1002,7 +1002,8 @@ void GuiMenu::openSystemSettings_batocera()
 		brightnessComponent->setValue(brighness);
 		brightnessComponent->setOnValueChanged([](const float &newVal)
 		{
-			ApiSystem::getInstance()->setBrighness((int)Math::round(newVal));
+			float mappedQuadratic = pow(newVal, 2.0f) / 100.0f; // equals 100 * x^2 / 100^2
+			ApiSystem::getInstance()->setBrighness((int)(mappedQuadratic + 0.5));
 		});
 
 		s->addWithLabel(_("BRIGHTNESS"), brightnessComponent);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -998,7 +998,7 @@ void GuiMenu::openSystemSettings_batocera()
 	int brighness;
 	if (ApiSystem::getInstance()->getBrighness(brighness))
 	{
-		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 5.f, 100.f, 5.f, "%");
+		auto brightnessComponent = std::make_shared<SliderComponent>(mWindow, 0, 100.f, 5.f, "%");
 		brightnessComponent->setValue(brighness);
 		brightnessComponent->setOnValueChanged([](const float &newVal)
 		{


### PR DESCRIPTION
These 3 patches allow the user to lower the brightness level as low as 1 in `/sys/class/backlight/backlight/brightness`.
The user facing range will be 0-100%, while the actual written range will be 1-100%.

In addition I map the ES value quadratically to the hardware value: 
![es-brightness](https://user-images.githubusercontent.com/295622/75624719-148ab980-5bb7-11ea-8427-df74aa86ac4a.png)

This makes the lower range values occupy more space in the range, resulting in a more linear transition on the screen.

I actually could measure the screen brightness using a colorimeter to come up with a function based on calibration, but this is better than before.