### PR TITLE
Fix analog stick usage

### DIFF
--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -114,17 +114,17 @@ bool InputConfig::isMappedTo(const std::string& name, Input input, bool reversed
 	return false;
 }
 
-bool InputConfig::isMappedLike(const std::string& name, Input input) // batocera
+bool InputConfig::isMappedLike(const std::string& name, Input input)
 {
 	if(name == "left")
 	{
-	  return isMappedTo("left", input) || isMappedTo("joystick1left", input); // batocera
+		return isMappedTo("left", input) || isMappedTo("leftanalogleft", input) || isMappedTo("rightanalogleft", input);
 	}else if(name == "right"){
-	  return isMappedTo("right", input) || isMappedTo("joystick1left", input, true); // batocera
+		return isMappedTo("right", input) || isMappedTo("leftanalogright", input) || isMappedTo("rightanalogright", input);
 	}else if(name == "up"){
-	  return isMappedTo("up", input) || isMappedTo("joystick1up", input); // batocera
+		return isMappedTo("up", input) || isMappedTo("leftanalogup", input) || isMappedTo("rightanalogup", input);
 	}else if(name == "down"){
-	  return isMappedTo("down", input) || isMappedTo("joystick1up", input, true); // batocera
+		return isMappedTo("down", input) || isMappedTo("leftanalogdown", input) || isMappedTo("rightanalogdown", input);
 	}
 	return isMappedTo(name, input);
 }


### PR DESCRIPTION
This reverts commit https://github.com/batocera-linux/batocera-emulationstation/commit/8b6c02d961845bce70f7a3fe55914afb8014c6c4 from batocera.

Apparently batocera uses a differnet `joystick1left` name for the analog stick input in emulationstation.
EmuELEC although uses the upstream default names for the analog stick `leftanalogleft` etc, as provided in the `es_input.cfg`.

This patch was tested and fixes the analog stick navigation on the OGA for me, but should fix it for all controllers, even newly configured ones.

A more friendly way to patch this from batocera's side would have been to leave the default names and just add their extra naming convention to make it work with both.