### PR TITLE
Add systemcommand support to system menu / DIRECT START OPTION

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1107,6 +1107,7 @@ SystemData* SystemData::loadSystem(pugi::xml_node system, bool fullMode)
 	envData->mStartPath = path;
 	envData->mSearchExtensions = extensions;
 	envData->mLaunchCommand = cmd;
+	envData->mSystemCommand = system.child("systemcommand").text().get();
 	envData->mPlatformIds = platformIds;
 	envData->mGroup = system.child("group").text().get();
 	

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -53,6 +53,7 @@ struct SystemEnvironmentData
 	std::string mStartPath;
 	std::set<std::string> mSearchExtensions;
 	std::string mLaunchCommand;
+	std::string mSystemCommand;
 	std::set<PlatformIds::PlatformId> mPlatformIds;
 	std::string mGroup;
 
@@ -95,6 +96,7 @@ public:
 	inline const std::set<std::string>& getExtensions() const { return mEnvData->mSearchExtensions; }
 	inline const std::string& getThemeFolder() const { return mMetadata.themeFolder; }
 	inline SystemEnvironmentData* getSystemEnvData() const { return mEnvData; }
+	inline const std::string& getSystemCommand() const { return mEnvData->mSystemCommand; }
 	inline const std::set<PlatformIds::PlatformId>& getPlatformIds() const { return mEnvData->mPlatformIds; }
 	inline bool hasPlatformId(PlatformIds::PlatformId id) { if (!mEnvData) return false; return mEnvData->mPlatformIds.find(id) != mEnvData->mPlatformIds.cend(); }
 	inline const SystemMetadata& getSystemMetadata() const { return mMetadata; }

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -522,7 +522,28 @@ bool SystemView::input(InputConfig* config, Input input)
 		if (config->isMappedTo(BUTTON_OK, input))
 		{
 			mCarousel.stopScrolling();
-			ViewController::get()->goToGameList(getSelected());
+
+			SystemData* selectedSystem = getSelected();
+
+			if (selectedSystem != nullptr && !selectedSystem->getSystemCommand().empty())
+			{
+				std::string command = selectedSystem->getSystemCommand();
+
+				command = Utils::String::replace(
+					command,
+					"%SYSTEM%",
+					selectedSystem->getName());
+
+				LOG(LogInfo) << "Launching system command: " << command;
+
+				int exitCode = system(command.c_str());
+
+				LOG(LogInfo) << "System command exited with code " << exitCode;
+
+				return true;
+			}
+
+			ViewController::get()->goToGameList(selectedSystem);
 			return true;
 		}
 


### PR DESCRIPTION
With this modification, the user now can directly start a script when clicking on a system logo.

To activate it, all is needed to add a new line in the system block of es_systems.cfg and it will over-ride the normal function of showing the gamelist of that system. For example:

<systemcommand>/storage/roms/ports_scripts/XMPlayer.sh</systemcommand>
